### PR TITLE
standardError-bugfix

### DIFF
--- a/MedallionShell/ProcessCommand.cs
+++ b/MedallionShell/ProcessCommand.cs
@@ -111,7 +111,7 @@ namespace Medallion.Shell
             get 
             {
                 Throw<InvalidOperationException>.If(this.standardErrorHandler == null, "Standard error is not redirected");
-                return this.standardOutputHandler.Reader;
+                return this.standardErrorHandler.Reader;
             }
         }
 


### PR DESCRIPTION
There was a standardOutputHandler instead of standardErrorHandler
