### PR TITLE
Add .NET Core build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ project.lock.json
 *.nupkg
 #MA: using nuget package restore!
 packages/
+
+# Cake tools
+tools/

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ obj/
 [Bb]in
 [Dd]ebug*/
 [Rr]elease*/
+.vs/
 
 #upgrade from 2010
 Backup/*
@@ -45,6 +46,7 @@ StyleCop.Cache
 
 #Project files 
 [Bb]uild/
+project.lock.json
 
 #Nuget Files
 *.nupkg

--- a/MedallionShell.NetCore.Tests/MedallionShell.NetCore.Tests.xproj
+++ b/MedallionShell.NetCore.Tests/MedallionShell.NetCore.Tests.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>70278258-c165-4112-a0db-2183b5e0d1f8</ProjectGuid>
+    <RootNamespace>MedallionShell.NetCore.Tests</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/MedallionShell.NetCore.Tests/project.json
+++ b/MedallionShell.NetCore.Tests/project.json
@@ -1,0 +1,34 @@
+{
+	"version": "1.0.0-*",
+  "testRunner": "xunit",
+
+  "dependencies": {
+    "NETStandard.Library": "1.6.0",
+    "System.Diagnostics.Process": "4.1.0",
+    "MedallionShell.NetCore": "1.0.0-*",
+    "xunit": "2.2.0-*",
+    "dotnet-test-xunit": "2.2.0-*",
+    "System.Reflection.Extensions": "4.0.1"
+  },
+
+  "frameworks": {
+    "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.1"
+        }
+      }
+    }
+  },
+
+  "buildOptions": {
+    "define": [ "NETCORE" ],
+    "compile": {
+      "include": "../MedallionShell.Tests/**/*.cs"
+    }
+  }
+
+
+  
+}

--- a/MedallionShell.NetCore/MedallionShell.NetCore.xproj
+++ b/MedallionShell.NetCore/MedallionShell.NetCore.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>25267c09-ee93-4573-97cc-a849de61fd94</ProjectGuid>
+    <RootNamespace>MedallionShell.NetCore</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/MedallionShell.NetCore/project.json
+++ b/MedallionShell.NetCore/project.json
@@ -1,0 +1,22 @@
+﻿{
+  "title": "MedallionShell",
+  "version": "1.0.0-*",
+
+  "dependencies": {
+    "NETStandard.Library": "1.6.0",
+    "System.Diagnostics.Process": "4.1.0" 
+  },
+
+  "frameworks": {
+    "netstandard1.3": {
+    }
+  },
+
+  "buildOptions": {
+    "compile": {
+      "include": "../MedallionShell/**/*.cs"
+    },
+    "outputName": "MedallionShell",
+    "define": ["NETCORE"]
+  }
+}

--- a/MedallionShell.Tests/GeneralTest.cs
+++ b/MedallionShell.Tests/GeneralTest.cs
@@ -1,30 +1,26 @@
-﻿using Medallion.Shell;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Xunit;
 
 namespace Medallion.Shell.Tests
 {
-    [TestClass]
     public class GeneralTest
     {
-        [TestMethod]
+        [Fact]
         public void TestGrep()
         {
             var command = Shell.Default.Run("SampleCommand", "grep", "a+");
             command.StandardInput.WriteLine("hi");
             command.StandardInput.WriteLine("aa");
-            command.StandardInput.Close();
+            command.StandardInput.Dispose();
             command.StandardOutput.ReadToEnd().ShouldEqual("aa\r\n");
         }
 
-        [TestMethod]
+        [Fact]
         public void TestPipedGrep()
         {
             Log.WriteLine("******** TestPipedGrep starting *********");
@@ -40,7 +36,7 @@ namespace Medallion.Shell.Tests
             results.SequenceEqual(new[] { "abcd", "abc" }).ShouldEqual(true);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestLongWriteWithInfrequentReads()
         {
             var lines = Enumerable.Range(0, 100).Select(i => i.ToString())
@@ -77,7 +73,7 @@ namespace Medallion.Shell.Tests
             string.Join("/", outputLines).ShouldEqual(string.Join("/", lines));
         }
 
-        [TestMethod]
+        [Fact]
         public void TestHead()
         {
             var shell = new Shell(o => o.StartInfo(si => si.RedirectStandardError = false));
@@ -85,7 +81,7 @@ namespace Medallion.Shell.Tests
             command.Task.Result.StandardOutput.Trim().ShouldEqual(string.Join(Environment.NewLine, Enumerable.Range(0, 10)));
         }
 
-        [TestMethod]
+        [Fact]
         public void TestCloseStandardOutput()
         {
             var shell = new Shell(o => o.StartInfo(si => si.RedirectStandardError = false));
@@ -93,63 +89,57 @@ namespace Medallion.Shell.Tests
             command.StandardOutput.BaseStream.ReadByte();
             command.StandardOutput.BaseStream.Dispose();
             
-            UnitTestHelpers.AssertThrows<ObjectDisposedException>(() => command.StandardOutput.BaseStream.ReadByte());
-            UnitTestHelpers.AssertThrows<ObjectDisposedException>(() => command.StandardOutput.ReadToEnd());
+            Assert.Throws<ObjectDisposedException>(() => command.StandardOutput.BaseStream.ReadByte());
+            Assert.Throws<ObjectDisposedException>(() => command.StandardOutput.ReadToEnd());
 
             var command2 = shell.Run("SampleCommand", "grep", "a") < Enumerable.Repeat(new string('a', 1000), 1000);
             command2.Wait();
             command2.StandardOutput.Dispose();
-            UnitTestHelpers.AssertThrows<ObjectDisposedException>(() => command2.StandardOutput.Read());
+            Assert.Throws<ObjectDisposedException>(() => command2.StandardOutput.Read());
         }
 
-        [TestMethod]
+        [Fact]
         public void TestExitCode()
         {
-            if (!Command.Run("SampleCommand", "exit", 0).Result.Success)
-            {
-                Assert.Fail("Should have worked");
-            }
-            if (Command.Run("SampleCommand", "exit", 1).Result.Success)
-            {
-                Assert.Fail("Should have failed");
-            }
+            Assert.True(Command.Run("SampleCommand", "exit", 0).Result.Success);
+            Assert.False(Command.Run("SampleCommand", "exit", 1).Result.Success);
 
             var shell = new Shell(o => o.ThrowOnError());
-            var ex = UnitTestHelpers.AssertThrows<AggregateException>(() => shell.Run("SampleCommand", "exit", -1).Task.Wait());
+            var ex = Assert.Throws<AggregateException>(() => shell.Run("SampleCommand", "exit", -1).Task.Wait());
             ex.InnerExceptions.Select(e => e.GetType()).SequenceEqual(new[] { typeof(ErrorExitCodeException) })
                 .ShouldEqual(true);
 
             shell.Run("SampleCommand", "exit", 0).Task.Wait();
         }
 
-        [TestMethod]
+        [Fact]
         public void TestThrowOnErrorWithTimeout()
         {
             var command = Command.Run("SampleCommand", new object[] { "exit", 1 }, o => o.ThrowOnError().Timeout(TimeSpan.FromDays(1)));
-            var ex = UnitTestHelpers.AssertThrows<AggregateException>(() => command.Task.Wait());
+            var ex = Assert.Throws<AggregateException>(() => command.Task.Wait());
             ex.InnerExceptions.Select(e => e.GetType()).SequenceEqual(new[] { typeof(ErrorExitCodeException) })
                 .ShouldEqual(true);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestTimeout()
         {
             var willTimeout = Command.Run("SampleCommand", new object[] { "sleep", 1000000 }, o => o.Timeout(TimeSpan.FromMilliseconds(200)));
-            var ex = UnitTestHelpers.AssertThrows<AggregateException>(() => willTimeout.Task.Wait());
-            Assert.IsInstanceOfType(ex.InnerException, typeof(TimeoutException));
+            var ex = Assert.Throws<AggregateException>(() => willTimeout.Task.Wait());
+            Assert.IsType<TimeoutException>(ex.InnerException);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestErrorHandling()
         {
             var command = Command.Run("SampleCommand", "echo") < "abc" > new char[0];
-            UnitTestHelpers.AssertThrows<AggregateException>(() => command.Wait());
+            Assert.Throws<AggregateException>(() => command.Wait());
 
             var command2 = Command.Run("SampleCommand", "echo") < this.ErrorLines();
-            UnitTestHelpers.AssertThrows<AggregateException>(() => command.Wait());
+            Assert.Throws<AggregateException>(() => command.Wait());
         }
 
-        [TestMethod]
+        [Fact]
         public void TestStopBufferingAndDiscard()
         {
             var command = Command.Run("SampleCommand", "pipe");
@@ -178,14 +168,14 @@ namespace Medallion.Shell.Tests
                     task.Wait(TimeSpan.FromSeconds(.5)).ShouldEqual(true, "can finish after read");
                     if (state == 1)
                     {
-                        command.StandardInput.Close();
+                        command.StandardInput.Dispose();
                     }
                     state++;
                 }
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void TestKill()
         {
             var command = Command.Run("SampleCommand", "pipe");
@@ -201,7 +191,7 @@ namespace Medallion.Shell.Tests
             command.StandardOutput.ReadLine().ShouldEqual("abc");
         }
 
-        [TestMethod]
+        [Fact]
         public void TestKillAfterFinished()
         {
             var command = Command.Run("SampleCommand", "bool", true, "something");
@@ -210,7 +200,7 @@ namespace Medallion.Shell.Tests
             command.Result.Success.ShouldEqual(true);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestNestedKill()
         {
             var lines = new List<string>();
@@ -226,19 +216,19 @@ namespace Medallion.Shell.Tests
             pipeline.Result.Success.ShouldEqual(false);
             // This doesn't work right now due to our lack of flushing. There's not enought data so the single line gets caught
             // between pipes
-            UnitTestHelpers.AssertThrows<ArgumentOutOfRangeException>(() => lines[0].ShouldEqual("a line"));
+            Assert.Throws<ArgumentOutOfRangeException>(() => lines[0].ShouldEqual("a line"));
         }
 
-        [TestMethod]
+        [Fact]
         public void TestVersioning()
         {
-            var version = typeof(Command).Assembly.GetName().Version.ToString();
-            var informationalVersion = (AssemblyInformationalVersionAttribute)typeof(Command).Assembly.GetCustomAttribute(typeof(AssemblyInformationalVersionAttribute));
-            Assert.IsNotNull(informationalVersion);
+            var version = typeof(Command).GetTypeInfo().Assembly.GetName().Version.ToString();
+            var informationalVersion = (AssemblyInformationalVersionAttribute)typeof(Command).GetTypeInfo().Assembly.GetCustomAttribute(typeof(AssemblyInformationalVersionAttribute));
+            Assert.NotNull(informationalVersion);
             version.ShouldEqual(informationalVersion.InformationalVersion + ".0");
         }
 
-        [TestMethod]
+        [Fact]
         public void TestShortFlush()
         {
             var command = Command.Run("SampleCommand", "shortflush", "a");
@@ -246,11 +236,11 @@ namespace Medallion.Shell.Tests
             //var readCommand = command.StandardOutput.BaseStream.ReadAsync(new byte[1], 0, 1);
             readCommand.Wait(TimeSpan.FromSeconds(5)).ShouldEqual(true);
 
-            command.StandardInput.Close();
+            command.StandardInput.Dispose();
             command.Task.Wait(TimeSpan.FromSeconds(5)).ShouldEqual(true);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestAutoFlush()
         {
             var command = Command.Run("SampleCommand", "echo", "--per-char");
@@ -270,10 +260,10 @@ namespace Medallion.Shell.Tests
             asyncRead.Wait(TimeSpan.FromSeconds(3)).ShouldEqual(true);
             buffer[0].ShouldEqual('b');
 
-            command.StandardInput.Close();
+            command.StandardInput.Dispose();
         }
 
-        [TestMethod]
+        [Fact]
         public void TestErrorEcho()
         {
             var command = Command.Run("SampleCommand", "errecho") < "abc";

--- a/MedallionShell.Tests/MedallionShell.Tests.csproj
+++ b/MedallionShell.Tests/MedallionShell.Tests.csproj
@@ -46,6 +46,22 @@
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.abstractions.2.0.1-rc2\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.assert, Version=2.2.0.3300, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.assert.2.2.0-beta2-build3300\lib\netstandard1.0\xunit.assert.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.2.0.3300, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.core.2.2.0-beta2-build3300\lib\net45\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.2.0.3300, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.execution.2.2.0-beta2-build3300\lib\net45\xunit.execution.desktop.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
@@ -53,11 +69,7 @@
         <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
       </ItemGroup>
     </When>
-    <Otherwise>
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
-      </ItemGroup>
-    </Otherwise>
+    <Otherwise />
   </Choose>
   <ItemGroup>
     <Compile Include="GeneralTest.cs" />
@@ -76,6 +88,9 @@
       <Project>{1f78eb31-414f-4c1e-893b-c281f6b4ffc0}</Project>
       <Name>SampleCommand</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">

--- a/MedallionShell.Tests/PipeTest.cs
+++ b/MedallionShell.Tests/PipeTest.cs
@@ -1,17 +1,16 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Xunit;
 
 namespace Medallion.Shell.Tests
 {
-    [TestClass]
-    public class PipeTest
+    public class PipeTest : IDisposable
     {
-        [TestMethod]
+        [Fact]
         public void TestPiping()
         {
             var shell = new Shell(o => o.ThrowOnError());
@@ -68,7 +67,7 @@ namespace Medallion.Shell.Tests
             switch (kind)
             {
                 case Kind.Stream:
-                    return isOut ? new MemoryStream() : new MemoryStream(Encoding.Default.GetBytes(Content));
+                    return isOut ? new MemoryStream() : new MemoryStream(Encoding.UTF8.GetBytes(Content));
                 case Kind.File:
                     var path = GetPath(isOut);
                     if (!isOut)
@@ -94,7 +93,7 @@ namespace Medallion.Shell.Tests
             switch (kind)
             {
                 case Kind.Stream:
-                    return Encoding.Default.GetString(((MemoryStream)output).ToArray());
+                    return Encoding.UTF8.GetString(((MemoryStream)output).ToArray());
                 case Kind.File:
                     return File.ReadAllText(GetPath(isOut: true));
                 case Kind.ReaderWriter:
@@ -108,7 +107,11 @@ namespace Medallion.Shell.Tests
             }
         }
 
-        [ClassCleanup]
+        public void Dispose()
+        {
+            TearDown();
+        }
+        
         public static void TearDown()
         {
             foreach (var isOut in new[] { false, true })

--- a/MedallionShell.Tests/SyntaxTest.cs
+++ b/MedallionShell.Tests/SyntaxTest.cs
@@ -1,16 +1,15 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Xunit;
 
 namespace Medallion.Shell.Tests
 {
-    [TestClass]
     public class SyntaxTest
     {
-        [TestMethod]
+        [Fact]
         public void DirectTestWindowsSyntax()
         {
             this.TestSyntax(" ");

--- a/MedallionShell.Tests/UnitTestHelpers.cs
+++ b/MedallionShell.Tests/UnitTestHelpers.cs
@@ -1,9 +1,9 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Xunit;
 
 namespace Medallion.Shell.Tests
 {
@@ -11,29 +11,9 @@ namespace Medallion.Shell.Tests
     {
         public static T ShouldEqual<T>(this T @this, T that, string message = null)
         {
-            Assert.AreEqual(that, @this, message);
+            Assert.Equal(that, @this);
             return @this;
         }
 
-        public static TException AssertThrows<TException>(Action action)
-            where TException : Exception
-        {
-            try
-            {
-                action();
-            }
-            catch (Exception ex)
-            {
-                var result = ex as TException;
-                if (result == null)
-                {
-                    Assert.Fail("Expected {0}, got {1}", typeof(TException), ex);
-                }
-                return result;
-            }
-
-            Assert.Fail("Expected {0}, but no exception was thrown", typeof(TException));
-            return null;
-        }
     }
 }

--- a/MedallionShell.Tests/packages.config
+++ b/MedallionShell.Tests/packages.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="xunit" version="2.2.0-beta2-build3300" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.1-rc2" targetFramework="net45" />
+  <package id="xunit.assert" version="2.2.0-beta2-build3300" targetFramework="net45" />
+  <package id="xunit.core" version="2.2.0-beta2-build3300" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.2.0-beta2-build3300" targetFramework="net45" />
+  <package id="xunit.extensibility.execution" version="2.2.0-beta2-build3300" targetFramework="net45" />
+</packages>

--- a/MedallionShell.nuspec
+++ b/MedallionShell.nuspec
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    <id>MedallionShell</id>
+    <version>1.1.0</version>
+    <title>Medallion Shell</title>
+    <authors>Michael Adelson</authors>
+    <owners>Michael Adelson</owners>
+    <licenseUrl>https://raw.githubusercontent.com/madelson/MedallionShell/master/License.txt</licenseUrl>
+    <projectUrl>https://github.com/madelson/MedallionShell</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>A lightweight library that simplifies working with processes in .NET</description>
+    <summary>A lightweight library that simplifies working with processes in .NET</summary>
+    <releaseNotes>Added AutoFlush support and fixed bug where small flushed data packets got stuck in the buffer</releaseNotes>
+    <copyright>Copyright 2014</copyright>
+    <tags>process async</tags>
+    <dependencies>
+      <group targetFramework="net45"></group>
+      <group targetFramework="netstandard1.3">
+        <dependency id="NETStandard.Library" version="1.6.0"/>
+        <dependency id="System.Diagnostics.Process" version="4.1.0"/>
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="MedallionShell\bin\Release\MedallionShell.dll" target="lib\net45"/>
+    <file src="MedallionShell.NetCore\bin\Release\netstandard1.3\MedallionShell.dll" target="lib\netstandard1.3"/>
+  </files>
+</package>

--- a/MedallionShell.sln
+++ b/MedallionShell.sln
@@ -16,6 +16,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionItems", "SolutionIt
 		MedallionShell.nuspec = MedallionShell.nuspec
 	EndProjectSection
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "MedallionShell.NetCore.Tests", "MedallionShell.NetCore.Tests\MedallionShell.NetCore.Tests.xproj", "{70278258-C165-4112-A0DB-2183B5E0D1F8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -47,6 +49,12 @@ Global
 		{25267C09-EE93-4573-97CC-A849DE61FD94}.Release|Any CPU.Build.0 = Release|Any CPU
 		{25267C09-EE93-4573-97CC-A849DE61FD94}.Testing|Any CPU.ActiveCfg = Debug|Any CPU
 		{25267C09-EE93-4573-97CC-A849DE61FD94}.Testing|Any CPU.Build.0 = Debug|Any CPU
+		{70278258-C165-4112-A0DB-2183B5E0D1F8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{70278258-C165-4112-A0DB-2183B5E0D1F8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{70278258-C165-4112-A0DB-2183B5E0D1F8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{70278258-C165-4112-A0DB-2183B5E0D1F8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{70278258-C165-4112-A0DB-2183B5E0D1F8}.Testing|Any CPU.ActiveCfg = Debug|Any CPU
+		{70278258-C165-4112-A0DB-2183B5E0D1F8}.Testing|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/MedallionShell.sln
+++ b/MedallionShell.sln
@@ -1,13 +1,20 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Express 2013 for Windows Desktop
-VisualStudioVersion = 12.0.21005.1
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MedallionShell", "MedallionShell\MedallionShell.csproj", "{15AF2EC0-F7B2-4206-B92A-DD1F3DC25F30}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MedallionShell.Tests", "MedallionShell.Tests\MedallionShell.Tests.csproj", "{1B474A08-2A88-4FEA-A290-0555556C8229}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleCommand", "SampleCommand\SampleCommand.csproj", "{1F78EB31-414F-4C1E-893B-C281F6B4FFC0}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "MedallionShell.NetCore", "MedallionShell.NetCore\MedallionShell.NetCore.xproj", "{25267C09-EE93-4573-97CC-A849DE61FD94}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionItems", "SolutionItems", "{AAB23959-DBE8-4DE6-882C-6C5F18248FE7}"
+	ProjectSection(SolutionItems) = preProject
+		MedallionShell.nuspec = MedallionShell.nuspec
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -34,6 +41,12 @@ Global
 		{1F78EB31-414F-4C1E-893B-C281F6B4FFC0}.Release|Any CPU.Build.0 = Release|Any CPU
 		{1F78EB31-414F-4C1E-893B-C281F6B4FFC0}.Testing|Any CPU.ActiveCfg = Testing|Any CPU
 		{1F78EB31-414F-4C1E-893B-C281F6B4FFC0}.Testing|Any CPU.Build.0 = Testing|Any CPU
+		{25267C09-EE93-4573-97CC-A849DE61FD94}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{25267C09-EE93-4573-97CC-A849DE61FD94}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{25267C09-EE93-4573-97CC-A849DE61FD94}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{25267C09-EE93-4573-97CC-A849DE61FD94}.Release|Any CPU.Build.0 = Release|Any CPU
+		{25267C09-EE93-4573-97CC-A849DE61FD94}.Testing|Any CPU.ActiveCfg = Debug|Any CPU
+		{25267C09-EE93-4573-97CC-A849DE61FD94}.Testing|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/MedallionShell/Properties/AssemblyInfo.cs
+++ b/MedallionShell/Properties/AssemblyInfo.cs
@@ -38,3 +38,4 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyFileVersion("1.0.0.0")]
 
 [assembly: InternalsVisibleTo("MedallionShell.Tests")]
+[assembly: InternalsVisibleTo("MedallionShell.NetCore.Tests")]

--- a/MedallionShell/Shell.cs
+++ b/MedallionShell/Shell.cs
@@ -165,6 +165,7 @@ namespace Medallion.Shell
                 return this.StartInfo(psi => psi.WorkingDirectory = path);
             }
 
+#if !NETCORE
             /// <summary>
             /// Adds or overwrites an environment variable to be passed to the <see cref="Command"/>
             /// </summary>
@@ -185,6 +186,7 @@ namespace Medallion.Shell
                 var environmentVariablesList = environmentVariables.ToList();
                 return this.StartInfo(psi => environmentVariablesList.ForEach(kvp => psi.EnvironmentVariables[kvp.Key] = kvp.Value));
             }
+#endif
 
             /// <summary>
             /// If specified, a non-zero exit code will cause the <see cref="Command"/>'s <see cref="Task"/> to fail

--- a/MedallionShell/Streams/InternalProcessStreamReader.cs
+++ b/MedallionShell/Streams/InternalProcessStreamReader.cs
@@ -45,12 +45,17 @@ namespace Medallion.Shell.Streams
             }
             finally
             {
+#if NETCORE
+                this.processStream.Dispose();
+                this.pipe.InputStream.Dispose();
+#else
                 this.processStream.Close();
                 this.pipe.InputStream.Close();
+#endif
             }
         }
 
-        #region ---- ProcessStreamReader implementation ----
+#region ---- ProcessStreamReader implementation ----
         public override Stream BaseStream
         {
             get { return this.reader.BaseStream; }
@@ -69,9 +74,9 @@ namespace Medallion.Shell.Streams
             // may still be buffered)
             this.pipe.SetFixedLength();
         }
-        #endregion
+#endregion
 
-        #region ---- TextReader implementation ----
+#region ---- TextReader implementation ----
         // all reader methods are overriden to call the same method on the underlying StreamReader.
         // This approach is preferable to extending StreamReader directly, since many of the async methods
         // on StreamReader are conservative and fall back to threaded asynchrony when inheritance is in play
@@ -134,6 +139,6 @@ namespace Medallion.Shell.Streams
                 this.Discard();
             }
         }
-        #endregion
+#endregion
     }
 }

--- a/MedallionShell/Streams/Pipe.cs
+++ b/MedallionShell/Streams/Pipe.cs
@@ -472,6 +472,7 @@ namespace Medallion.Shell.Streams
 
             public PipeInputStream(Pipe pipe) { this.pipe = pipe; }
 
+#if !NETCORE
             public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
             {
                 throw WriteOnly();
@@ -488,6 +489,7 @@ namespace Medallion.Shell.Streams
                 }
                 return writeResult;
             }
+#endif
 
             private sealed class AsyncWriteResult : IAsyncResult
             {
@@ -523,10 +525,12 @@ namespace Medallion.Shell.Streams
 
             public override bool CanWrite { get { return true; } }
 
+#if !NETCORE
             public override void Close()
             {
                 base.Close(); // calls Dispose(true)
             }
+#endif
 
             public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
             {
@@ -541,6 +545,7 @@ namespace Medallion.Shell.Streams
                 }
             }
 
+#if !NETCORE
             public override int EndRead(IAsyncResult asyncResult)
             {
                 throw WriteOnly();
@@ -553,6 +558,7 @@ namespace Medallion.Shell.Streams
                 Throw.If(writeResult == null || writeResult.Stream != this, "asyncResult: must be created by this stream's BeginWrite method");
                 writeResult.WriteTask.Wait();
             }
+#endif
 
             public override void Flush()
             {
@@ -662,6 +668,7 @@ namespace Medallion.Shell.Streams
 
             public PipeOutputStream(Pipe pipe) { this.pipe = pipe; }
 
+#if !NETCORE
             public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
             {
                 // according to the docs, the callback is optional
@@ -673,6 +680,7 @@ namespace Medallion.Shell.Streams
                 }
                 return readResult;
             }
+#endif
 
             private sealed class AsyncReadResult : IAsyncResult
             {
@@ -700,10 +708,12 @@ namespace Medallion.Shell.Streams
                 bool IAsyncResult.IsCompleted { get { return this.readTask.IsCompleted; } }
             }
 
+#if !NETCORE
             public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
             {
                 throw ReadOnly();
             }
+#endif
 
             public override bool CanRead { get { return true; } }
 
@@ -713,10 +723,12 @@ namespace Medallion.Shell.Streams
 
             public override bool CanWrite { get { return false; } }
 
+#if !NETCORE
             public override void Close()
             {
                 base.Close(); // calls Dispose(true)
             }
+#endif
 
             public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
             {
@@ -732,6 +744,7 @@ namespace Medallion.Shell.Streams
                 }
             }
 
+#if !NETCORE
             public override int EndRead(IAsyncResult asyncResult)
             {
                 Throw.IfNull(asyncResult, "asyncResult");
@@ -745,6 +758,7 @@ namespace Medallion.Shell.Streams
             {
                 throw ReadOnly();
             }
+#endif
 
             public override void Flush()
             {

--- a/SampleCommand/SampleCommand.csproj
+++ b/SampleCommand/SampleCommand.csproj
@@ -66,4 +66,7 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <Target Name="AfterBuild">
+    <Copy SourceFiles="bin/$(Configuration)/SampleCommand.exe" DestinationFiles="../MedallionShell.NetCore.Tests/SampleCommand.exe"/>
+  </Target>
 </Project>

--- a/build.cake
+++ b/build.cake
@@ -1,0 +1,55 @@
+#tool "nuget:?package=xunit.runner.console"
+var target = Argument("target", "Default");
+
+Task("CompileSampleCommand")
+  .Does(() => {
+  MSBuild("SampleCommand/SampleCommand.csproj");
+});
+
+
+Task("CompileNetCore")
+  .Does(() =>
+{
+  DotNetCoreBuild("MedallionShell.NetCore");
+});
+
+Task("TestNetCore")
+  .IsDependentOn("CompileNetCore")
+  .IsDependentOn("CompileSampleCommand")
+  .Does(() =>
+{
+  CopyFile("SampleCommand/bin/Debug/SampleCommand.exe", "SampleCommand.exe");
+  try {
+    DotNetCoreTest("MedallionShell.NetCore.Tests");
+  } finally {
+    DeleteFile("SampleCommand.exe");
+  }
+});
+
+Task("CompileNet45")
+  .Does(()=>{
+  MSBuild("MedallionShell/MedallionShell.csproj");
+});
+
+Task("CompileNet45Tests")
+  .IsDependentOn("CompileNet45")
+  .Does(() => {
+  MSBuild("MedallionShell.Tests/MedallionShell.Tests.csproj");
+});
+
+Task("TestNet45")
+  .IsDependentOn("CompileNet45")
+  .IsDependentOn("CompileNet45Tests")
+  .Does(()=>{
+  XUnit2("MedallionShell.Tests/bin/Debug/MedallionShell.Tests.dll");
+});
+
+Task("Default")
+  .IsDependentOn("TestNet45")
+  .IsDependentOn("TestNetCore")
+  .Does(() =>
+{
+  Information("Hello World!");
+});
+
+RunTarget(target);

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,189 @@
+##########################################################################
+# This is the Cake bootstrapper script for PowerShell.
+# This file was downloaded from https://github.com/cake-build/resources
+# Feel free to change this file to fit your needs.
+##########################################################################
+
+<#
+
+.SYNOPSIS
+This is a Powershell script to bootstrap a Cake build.
+
+.DESCRIPTION
+This Powershell script will download NuGet if missing, restore NuGet tools (including Cake)
+and execute your Cake build script with the parameters you provide.
+
+.PARAMETER Script
+The build script to execute.
+.PARAMETER Target
+The build script target to run.
+.PARAMETER Configuration
+The build configuration to use.
+.PARAMETER Verbosity
+Specifies the amount of information to be displayed.
+.PARAMETER Experimental
+Tells Cake to use the latest Roslyn release.
+.PARAMETER WhatIf
+Performs a dry run of the build script.
+No tasks will be executed.
+.PARAMETER Mono
+Tells Cake to use the Mono scripting engine.
+.PARAMETER SkipToolPackageRestore
+Skips restoring of packages.
+.PARAMETER ScriptArgs
+Remaining arguments are added here.
+
+.LINK
+http://cakebuild.net
+
+#>
+
+[CmdletBinding()]
+Param(
+    [string]$Script = "build.cake",
+    [string]$Target = "Default",
+    [ValidateSet("Release", "Debug")]
+    [string]$Configuration = "Release",
+    [ValidateSet("Quiet", "Minimal", "Normal", "Verbose", "Diagnostic")]
+    [string]$Verbosity = "Verbose",
+    [switch]$Experimental,
+    [Alias("DryRun","Noop")]
+    [switch]$WhatIf,
+    [switch]$Mono,
+    [switch]$SkipToolPackageRestore,
+    [Parameter(Position=0,Mandatory=$false,ValueFromRemainingArguments=$true)]
+    [string[]]$ScriptArgs
+)
+
+[Reflection.Assembly]::LoadWithPartialName("System.Security") | Out-Null
+function MD5HashFile([string] $filePath)
+{
+    if ([string]::IsNullOrEmpty($filePath) -or !(Test-Path $filePath -PathType Leaf))
+    {
+        return $null
+    }
+
+    [System.IO.Stream] $file = $null;
+    [System.Security.Cryptography.MD5] $md5 = $null;
+    try
+    {
+        $md5 = [System.Security.Cryptography.MD5]::Create()
+        $file = [System.IO.File]::OpenRead($filePath)
+        return [System.BitConverter]::ToString($md5.ComputeHash($file))
+    }
+    finally
+    {
+        if ($file -ne $null)
+        {
+            $file.Dispose()
+        }
+    }
+}
+
+Write-Host "Preparing to run build script..."
+
+if(!$PSScriptRoot){
+    $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
+}
+
+$TOOLS_DIR = Join-Path $PSScriptRoot "tools"
+$NUGET_EXE = Join-Path $TOOLS_DIR "nuget.exe"
+$CAKE_EXE = Join-Path $TOOLS_DIR "Cake/Cake.exe"
+$NUGET_URL = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
+$PACKAGES_CONFIG = Join-Path $TOOLS_DIR "packages.config"
+$PACKAGES_CONFIG_MD5 = Join-Path $TOOLS_DIR "packages.config.md5sum"
+
+# Should we use mono?
+$UseMono = "";
+if($Mono.IsPresent) {
+    Write-Verbose -Message "Using the Mono based scripting engine."
+    $UseMono = "-mono"
+}
+
+# Should we use the new Roslyn?
+$UseExperimental = "";
+if($Experimental.IsPresent -and !($Mono.IsPresent)) {
+    Write-Verbose -Message "Using experimental version of Roslyn."
+    $UseExperimental = "-experimental"
+}
+
+# Is this a dry run?
+$UseDryRun = "";
+if($WhatIf.IsPresent) {
+    $UseDryRun = "-dryrun"
+}
+
+# Make sure tools folder exists
+if ((Test-Path $PSScriptRoot) -and !(Test-Path $TOOLS_DIR)) {
+    Write-Verbose -Message "Creating tools directory..."
+    New-Item -Path $TOOLS_DIR -Type directory | out-null
+}
+
+# Make sure that packages.config exist.
+if (!(Test-Path $PACKAGES_CONFIG)) {
+    Write-Verbose -Message "Downloading packages.config..."
+    try { (New-Object System.Net.WebClient).DownloadFile("http://cakebuild.net/download/bootstrapper/packages", $PACKAGES_CONFIG) } catch {
+        Throw "Could not download packages.config."
+    }
+}
+
+# Try find NuGet.exe in path if not exists
+if (!(Test-Path $NUGET_EXE)) {
+    Write-Verbose -Message "Trying to find nuget.exe in PATH..."
+    $existingPaths = $Env:Path -Split ';' | Where-Object { (![string]::IsNullOrEmpty($_)) -and (Test-Path $_) }
+    $NUGET_EXE_IN_PATH = Get-ChildItem -Path $existingPaths -Filter "nuget.exe" | Select -First 1
+    if ($NUGET_EXE_IN_PATH -ne $null -and (Test-Path $NUGET_EXE_IN_PATH.FullName)) {
+        Write-Verbose -Message "Found in PATH at $($NUGET_EXE_IN_PATH.FullName)."
+        $NUGET_EXE = $NUGET_EXE_IN_PATH.FullName
+    }
+}
+
+# Try download NuGet.exe if not exists
+if (!(Test-Path $NUGET_EXE)) {
+    Write-Verbose -Message "Downloading NuGet.exe..."
+    try {
+        (New-Object System.Net.WebClient).DownloadFile($NUGET_URL, $NUGET_EXE)
+    } catch {
+        Throw "Could not download NuGet.exe."
+    }
+}
+
+# Save nuget.exe path to environment to be available to child processed
+$ENV:NUGET_EXE = $NUGET_EXE
+
+# Restore tools from NuGet?
+if(-Not $SkipToolPackageRestore.IsPresent) {
+    Push-Location
+    Set-Location $TOOLS_DIR
+
+    # Check for changes in packages.config and remove installed tools if true.
+    [string] $md5Hash = MD5HashFile($PACKAGES_CONFIG)
+    if((!(Test-Path $PACKAGES_CONFIG_MD5)) -Or
+      ($md5Hash -ne (Get-Content $PACKAGES_CONFIG_MD5 ))) {
+        Write-Verbose -Message "Missing or changed package.config hash..."
+        Remove-Item * -Recurse -Exclude packages.config,nuget.exe
+    }
+
+    Write-Verbose -Message "Restoring tools from NuGet..."
+    $NuGetOutput = Invoke-Expression "&`"$NUGET_EXE`" install -ExcludeVersion -OutputDirectory `"$TOOLS_DIR`""
+
+    if ($LASTEXITCODE -ne 0) {
+        Throw "An error occured while restoring NuGet tools."
+    }
+    else
+    {
+        $md5Hash | Out-File $PACKAGES_CONFIG_MD5 -Encoding "ASCII"
+    }
+    Write-Verbose -Message ($NuGetOutput | out-string)
+    Pop-Location
+}
+
+# Make sure that Cake has been installed.
+if (!(Test-Path $CAKE_EXE)) {
+    Throw "Could not find Cake.exe at $CAKE_EXE"
+}
+
+# Start Cake
+Write-Host "Running build script..."
+Invoke-Expression "& `"$CAKE_EXE`" `"$Script`" -target=`"$Target`" -configuration=`"$Configuration`" -verbosity=`"$Verbosity`" $UseMono $UseDryRun $UseExperimental $ScriptArgs"
+exit $LASTEXITCODE


### PR DESCRIPTION
This PR adds a project that builds a .NET Core version of MedallionShell and adds it to the main solution. Also included is a nuspec file to make it easy to package up the two assemblies into a single .nupkg.

Changes required are quite minor and are all contained in conditional sections (using the NETCORE compiler symbol).

I haven't bumped version numbers as I'll leave it to you to decide if this warrants a change to minor version or just to patch version - though I'd probably go with calling it 1.2.0 :-)
