### PR TITLE
Update InternalProcessStreamReader.cs

### DIFF
--- a/MedallionShell/Streams/InternalProcessStreamReader.cs
+++ b/MedallionShell/Streams/InternalProcessStreamReader.cs
@@ -23,7 +23,7 @@ namespace Medallion.Shell.Streams
         {
             this.processStream = processStreamReader.BaseStream;
             this.pipe = new Pipe();
-            this.reader = new StreamReader(this.pipe.OutputStream);
+            this.reader = new StreamReader(this.pipe.OutputStream, processStreamReader.CurrentEncoding);
             this.task = Task.Run(() => this.BufferLoop());
         }
 


### PR DESCRIPTION
InternalProcessStreamReader encoding must be same as original StreamReader.
Process StandardOutput is Encoding.Default, but StreamReader is Encoding.Utf8 by default, it will leads to messy code when Command.StandardOutput.ReadLine() or Command.StandardOutput.ReadToEnd().