### PR TITLE
Close #32 Searching for a file on the system path

### DIFF
--- a/MedallionShell.Tests/GeneralTest.cs
+++ b/MedallionShell.Tests/GeneralTest.cs
@@ -26,8 +26,10 @@ namespace Medallion.Shell.Tests
         [TestCase("powershell.exe", @"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe")]
         [TestCase("explorer.exe", @"C:\Windows\explorer.exe")]
         [TestCase("git.exe", @"C:\Program Files\Git\cmd\git.exe")]
-        [TestCase("echo", null)] // echo is not a program on Windows but an internal command in cmd.exe or powershell.exe
         [TestCase("does.not.exist", null)]
+        // echo is not a program on Windows but an internal command in cmd.exe or powershell.exe.
+        // However, things like git may still install echo (e.g. C:\Program Files\Git\usr\bin\echo.EXE)
+        // so there's no guarantee for echo on Windows.
         public void TestGetFullPathOnWindows(string executable, string? expected)
         {
             StringAssert.AreEqualIgnoringCase(expected, Shell.GetFullPathUsingSystemPathOrDefault(executable));
@@ -40,19 +42,19 @@ namespace Medallion.Shell.Tests
         [Platform("Unix", Reason = "Tests Unix-specific executables")]
         [TestCase("dotnet", "/usr/bin/dotnet")]
         [TestCase("which", "/usr/bin/which")]
-        [TestCase("sh", "/usr/bin/sh")]
-        [TestCase("ls", "/usr/bin/ls")]
-        [TestCase("grep", "/usr/bin/grep")]
         [TestCase("head", "/usr/bin/head")]
-        [TestCase("sleep", "/usr/bin/sleep")]
-        [TestCase("echo", "/usr/bin/echo")]
+        [TestCase("sh", "/bin/sh")]
+        [TestCase("ls", "/bin/ls")]
+        [TestCase("grep", "/bin/grep")]
+        [TestCase("sleep", "/bin/sleep")]
+        [TestCase("echo", "/bin/echo")]
         [TestCase("does.not.exist", null)]
         public void TestGetFullPathOnLinux(string executable, string? expected)
         {
             Shell.GetFullPathUsingSystemPathOrDefault(executable).ShouldEqual(expected);
             var command = Command.Run("which", executable);
             command.StandardOutput.ReadToEnd().Trim().ShouldEqual(
-                expected,
+                expected ?? string.Empty,
                 $"Exit code: {command.Result.ExitCode}, StdErr: '{command.Result.StandardError}'");
         }
 

--- a/MedallionShell.Tests/GeneralTest.cs
+++ b/MedallionShell.Tests/GeneralTest.cs
@@ -17,6 +17,51 @@ namespace Medallion.Shell.Tests
 
     public class GeneralTest
     {
+        [Platform("Win", Reason = "Tests Windows-specific executables")]
+        [TestCase("dotnet", @"C:\Program Files\dotnet\dotnet.exe")]
+        [TestCase("dotnet.exe", @"C:\Program Files\dotnet\dotnet.exe")]
+        [TestCase("where.exe", @"C:\Windows\System32\where.exe")]
+        [TestCase("cmd", @"C:\Windows\System32\cmd.exe")]
+        [TestCase("cmd.exe", @"C:\Windows\System32\cmd.exe")]
+        [TestCase("powershell.exe", @"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe")]
+        [TestCase("explorer.exe", @"C:\Windows\explorer.exe")]
+        [TestCase("git.exe", @"C:\Program Files\Git\cmd\git.exe")]
+        [TestCase("echo", null)] // echo is not a program on Windows but an internal command in cmd.exe or powershell.exe
+        [TestCase("does.not.exist", null)]
+        public void TestGetFullPathOnWindows(string executable, string? expected)
+        {
+            StringAssert.AreEqualIgnoringCase(expected, Shell.GetFullPathUsingSystemPathOrDefault(executable));
+            var command = Command.Run("where", executable);
+            command.StandardOutput.ReadToEnd().Trim().ShouldEqual(
+                expected ?? string.Empty,
+                $"Exit code: {command.Result.ExitCode}, StdErr: '{command.Result.StandardError}'");
+        }
+
+        [Platform("Unix", Reason = "Tests Unix-specific executables")]
+        [TestCase("dotnet", "/usr/bin/dotnet")]
+        [TestCase("which", "/usr/bin/which")]
+        [TestCase("sh", "/usr/bin/sh")]
+        [TestCase("ls", "/usr/bin/ls")]
+        [TestCase("grep", "/usr/bin/grep")]
+        [TestCase("head", "/usr/bin/head")]
+        [TestCase("sleep", "/usr/bin/sleep")]
+        [TestCase("echo", "/usr/bin/echo")]
+        [TestCase("does.not.exist", null)]
+        public void TestGetFullPathOnLinux(string executable, string? expected)
+        {
+            Shell.GetFullPathUsingSystemPathOrDefault(executable).ShouldEqual(expected);
+            var command = Command.Run("which", executable);
+            command.StandardOutput.ReadToEnd().Trim().ShouldEqual(
+                expected,
+                $"Exit code: {command.Result.ExitCode}, StdErr: '{command.Result.StandardError}'");
+        }
+
+        [Test]
+        public void TestCommandWithoutFullyQualifiedPath()
+        {
+            Assert.That(TestShell.Run("git", "--version").StandardOutput.ReadToEnd(), Does.StartWith("git version"));
+        }
+
         [Test]
         public void TestGrep()
         {

--- a/MedallionShell.Tests/GeneralTest.cs
+++ b/MedallionShell.Tests/GeneralTest.cs
@@ -17,47 +17,6 @@ namespace Medallion.Shell.Tests
 
     public class GeneralTest
     {
-        [Platform("Win", Reason = "Tests Windows-specific executables")]
-        [TestCase("dotnet", @"C:\Program Files\dotnet\dotnet.exe")]
-        [TestCase("dotnet.exe", @"C:\Program Files\dotnet\dotnet.exe")]
-        [TestCase("where.exe", @"C:\Windows\System32\where.exe")]
-        [TestCase("cmd", @"C:\Windows\System32\cmd.exe")]
-        [TestCase("cmd.exe", @"C:\Windows\System32\cmd.exe")]
-        [TestCase("powershell.exe", @"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe")]
-        [TestCase("explorer.exe", @"C:\Windows\explorer.exe")]
-        [TestCase("git.exe", @"C:\Program Files\Git\cmd\git.exe")]
-        [TestCase("does.not.exist", null)]
-        // echo is not a program on Windows but an internal command in cmd.exe or powershell.exe.
-        // However, things like git may still install echo (e.g. C:\Program Files\Git\usr\bin\echo.EXE)
-        // so there's no guarantee for echo on Windows.
-        public void TestGetFullPathOnWindows(string executable, string? expected)
-        {
-            StringAssert.AreEqualIgnoringCase(expected, Shell.GetFullPathUsingSystemPathOrDefault(executable));
-            var command = Command.Run("where", executable);
-            command.StandardOutput.ReadToEnd().Trim().ShouldEqual(
-                expected ?? string.Empty,
-                $"Exit code: {command.Result.ExitCode}, StdErr: '{command.Result.StandardError}'");
-        }
-
-        [Platform("Unix", Reason = "Tests Unix-specific executables")]
-        [TestCase("dotnet", "/usr/bin/dotnet")]
-        [TestCase("which", "/usr/bin/which")]
-        [TestCase("head", "/usr/bin/head")]
-        [TestCase("sh", "/bin/sh")]
-        [TestCase("ls", "/bin/ls")]
-        [TestCase("grep", "/bin/grep")]
-        [TestCase("sleep", "/bin/sleep")]
-        [TestCase("echo", "/bin/echo")]
-        [TestCase("does.not.exist", null)]
-        public void TestGetFullPathOnLinux(string executable, string? expected)
-        {
-            Shell.GetFullPathUsingSystemPathOrDefault(executable).ShouldEqual(expected);
-            var command = Command.Run("which", executable);
-            command.StandardOutput.ReadToEnd().Trim().ShouldEqual(
-                expected ?? string.Empty,
-                $"Exit code: {command.Result.ExitCode}, StdErr: '{command.Result.StandardError}'");
-        }
-
         [Test]
         public void TestCommandWithoutFullyQualifiedPath()
         {

--- a/MedallionShell.Tests/SystemPathSearcherTest.cs
+++ b/MedallionShell.Tests/SystemPathSearcherTest.cs
@@ -1,0 +1,49 @@
+﻿using NUnit.Framework;
+
+namespace Medallion.Shell.Tests;
+
+public class SystemPathSearcherTest
+{
+    [Platform("Win", Reason = "Tests Windows-specific executables")]
+    [TestCase("dotnet", @"C:\Program Files\dotnet\dotnet.exe")]
+    [TestCase("dotnet.exe", @"C:\Program Files\dotnet\dotnet.exe")]
+    [TestCase("where.exe", @"C:\Windows\System32\where.exe")]
+    [TestCase("cmd", @"C:\Windows\System32\cmd.exe")]
+    [TestCase("cmd.exe", @"C:\Windows\System32\cmd.exe")]
+    [TestCase("powershell.exe", @"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe")]
+    [TestCase("explorer.exe", @"C:\Windows\explorer.exe")]
+    [TestCase("git.exe", @"C:\Program Files\Git\cmd\git.exe")]
+    [TestCase("does.not.exist", null)]
+    // echo is not a program on Windows but an internal command in cmd.exe or powershell.exe.
+    // However, things like git may still install echo (e.g. C:\Program Files\Git\usr\bin\echo.EXE)
+    // so there's no guarantee for echo on Windows.
+    public void TestGetFullPathOnWindows(string executable, string? expected)
+    {
+        StringAssert.AreEqualIgnoringCase(expected, SystemPathSearcher.GetFullPathUsingSystemPathOrDefault(executable));
+
+        var command = Command.Run("where", executable);
+        command.StandardOutput.ReadToEnd().Trim().ShouldEqual(
+            expected ?? string.Empty,
+            $"Exit code: {command.Result.ExitCode}, StdErr: '{command.Result.StandardError}'");
+    }
+
+    [Platform("Unix", Reason = "Tests Unix-specific executables")]
+    [TestCase("dotnet", "/usr/bin/dotnet")]
+    [TestCase("which", "/usr/bin/which")]
+    [TestCase("head", "/usr/bin/head")]
+    [TestCase("sh", "/bin/sh")]
+    [TestCase("ls", "/bin/ls")]
+    [TestCase("grep", "/bin/grep")]
+    [TestCase("sleep", "/bin/sleep")]
+    [TestCase("echo", "/bin/echo")]
+    [TestCase("does.not.exist", null)]
+    public void TestGetFullPathOnLinux(string executable, string? expected)
+    {
+        SystemPathSearcher.GetFullPathUsingSystemPathOrDefault(executable).ShouldEqual(expected);
+
+        var command = Command.Run("which", executable);
+        command.StandardOutput.ReadToEnd().Trim().ShouldEqual(
+            expected ?? string.Empty,
+            $"Exit code: {command.Result.ExitCode}, StdErr: '{command.Result.StandardError}'");
+    }
+}

--- a/MedallionShell/Shell.cs
+++ b/MedallionShell/Shell.cs
@@ -39,8 +39,7 @@ namespace Medallion.Shell
 
             var finalOptions = this.GetOptions(options);
 
-            var executablePath = !executable.Contains(Path.DirectorySeparatorChar)
-                && finalOptions.SearchOnSystemPath
+            var executablePath = finalOptions.SearchOnSystemPath
                 && SystemPathSearcher.GetFullPathUsingSystemPathOrDefault(executable) is { } fullPath
                 ? fullPath
                 : executable;

--- a/MedallionShell/Shell.cs
+++ b/MedallionShell/Shell.cs
@@ -37,12 +37,13 @@ namespace Medallion.Shell
         {
             Throw.If(string.IsNullOrEmpty(executable), "executable is required");
 
+            var finalOptions = this.GetOptions(options);
+
             var executablePath = !executable.Contains(Path.DirectorySeparatorChar)
+                && finalOptions.SearchOnSystemPath
                 && SystemPathSearcher.GetFullPathUsingSystemPathOrDefault(executable) is { } fullPath
                 ? fullPath
                 : executable;
-
-            var finalOptions = this.GetOptions(options);
 
             var processStartInfo = new ProcessStartInfo
             {
@@ -207,6 +208,7 @@ namespace Medallion.Shell
             internal CommandLineSyntax CommandLineSyntax { get; private set; } = default!; // assigned in RestoreDefaults
             internal bool ThrowExceptionOnError { get; private set; }
             internal bool DisposeProcessOnExit { get; private set; }
+            internal bool SearchOnSystemPath { get; private set; }
             internal TimeSpan ProcessTimeout { get; private set; }
             internal Encoding? ProcessStreamEncoding { get; private set; }
             internal CancellationToken ProcessCancellationToken { get; private set; }
@@ -321,6 +323,17 @@ namespace Medallion.Shell
             public Options DisposeOnExit(bool value = true)
             {
                 this.DisposeProcessOnExit = value;
+                return this;
+            }
+
+            /// <summary>
+            /// If specified, the underlying <see cref="Process"/> will search for the system path, like a shell would.
+            ///
+            /// Defaults to false
+            /// </summary>
+            public Options SearchSystemPath(bool value = false)
+            {
+                this.SearchOnSystemPath = value;
                 return this;
             }
 

--- a/MedallionShell/Shell.cs
+++ b/MedallionShell/Shell.cs
@@ -6,7 +6,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -39,7 +38,7 @@ namespace Medallion.Shell
             Throw.If(string.IsNullOrEmpty(executable), "executable is required");
 
             var executablePath = !executable.Contains(Path.DirectorySeparatorChar)
-                && GetFullPathUsingSystemPathOrDefault(executable) is { } fullPath
+                && SystemPathSearcher.GetFullPathUsingSystemPathOrDefault(executable) is { } fullPath
                 ? fullPath
                 : executable;
 
@@ -81,24 +80,6 @@ namespace Medallion.Shell
             }
             
             return command;
-        }
-
-        // internal for testing
-        internal static string? GetFullPathUsingSystemPathOrDefault(string executable)
-        {
-            var paths = Environment.GetEnvironmentVariable("PATH")!.Split(Path.PathSeparator);
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                var pathExtensions = Environment.GetEnvironmentVariable("PATHEXT")!
-                    .Split(Path.PathSeparator)
-                    .Concat(new[] { string.Empty })
-                    .ToArray();
-                return paths.SelectMany(path => pathExtensions.Select(pathExtension => Path.Combine(path, executable + pathExtension)))
-                    .FirstOrDefault(File.Exists);
-            }
-
-            return paths.Select(path => Path.Combine(path, executable)).FirstOrDefault(File.Exists);
         }
 
         private static void PopulateArguments(ProcessStartInfo processStartInfo, IEnumerable<object?>? arguments, Options options)

--- a/MedallionShell/SystemPathSearcher.cs
+++ b/MedallionShell/SystemPathSearcher.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+
+namespace Medallion.Shell;
+
+internal static class SystemPathSearcher
+{
+    public static string? GetFullPathUsingSystemPathOrDefault(string executable)
+    {
+        var paths = Environment.GetEnvironmentVariable("PATH")!.Split(Path.PathSeparator);
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            var pathExtensions = Environment.GetEnvironmentVariable("PATHEXT")!
+                .Split(Path.PathSeparator)
+                .Concat([string.Empty])
+                .ToArray();
+            return paths.SelectMany(path => pathExtensions.Select(pathExtension => Path.Combine(path, executable + pathExtension)))
+                .FirstOrDefault(File.Exists);
+        }
+
+        return paths.Select(path => Path.Combine(path, executable)).FirstOrDefault(File.Exists);
+    }
+}


### PR DESCRIPTION
### Notes
Picked up this ticket because it seemed interesting, even though it was not in the 1.7 milestone.

### Context
There are a few different suggested approaches in [this StackOverflow thread](https://stackoverflow.com/questions/3855956/check-if-an-executable-exists-in-the-windows-path/3856090).
1. I went with [the most upvoted answer](https://stackoverflow.com/a/3856090), which seemed most reasonable and straightforward to me. Filing a PR to see if a variation of it works on Linux. I have not found any executables that didn't work with this approach (on Windows 11).
2. Invoking `Process.Start` on the executable itself (or calling `where` on Windows, `which` on Linux) is probably too expensive.
3. There's also [a mention of the built-in API `PathFindOnPath` in `shlwapi.dll`](https://stackoverflow.com/a/52435685/4370146), but I wasn't sure if it was reliable.

### Open Questions
1. Should we use `PathFindOnPath`, or is searching for `PATH` suffice?
2. Should we validate the length of the `executable`?
3. What other test cases do we want?