### PR TITLE
Support C# 12 by installing .NET 8 SDK in the Ubuntu pipeline

### DIFF
--- a/MedallionShell.Tests/CommandLineSyntaxTest.cs
+++ b/MedallionShell.Tests/CommandLineSyntaxTest.cs
@@ -16,7 +16,7 @@ namespace Medallion.Shell.Tests
         {
             var syntax = isWindowsSyntax ? new WindowsCommandLineSyntax() : new MonoUnixCommandLineSyntax().As<CommandLineSyntax>();
             Assert.Throws<ArgumentNullException>(() => syntax.CreateArgumentString(null!));
-            Assert.Throws<ArgumentException>(() => syntax.CreateArgumentString(new[] { "a", null!, "b" }));
+            Assert.Throws<ArgumentException>(() => syntax.CreateArgumentString(["a", null!, "b"]));
         }
         
         [TestCase(" ")]
@@ -43,7 +43,7 @@ namespace Medallion.Shell.Tests
         }
 
         [Test]
-        public void TestEmptyArgumentsRoundTrip() => this.TestArgumentsRoundTripHelper(Array.Empty<string>());
+        public void TestEmptyArgumentsRoundTrip() => this.TestArgumentsRoundTripHelper([]);
 
         private void TestArgumentsRoundTripHelper(string[] arguments)
         {

--- a/MedallionShell.Tests/GeneralTest.cs
+++ b/MedallionShell.Tests/GeneralTest.cs
@@ -110,7 +110,7 @@ namespace Medallion.Shell.Tests
 
             var shell = MakeTestShell(o => o.ThrowOnError());
             var ex = Assert.Throws<AggregateException>(() => shell.Run(SampleCommand, "exit", -1).Task.Wait());
-            ex!.InnerExceptions.Select(e => e.GetType()).SequenceEqual(new[] { typeof(ErrorExitCodeException) })
+            ex!.InnerExceptions.Select(e => e.GetType()).SequenceEqual([typeof(ErrorExitCodeException)])
                 .ShouldEqual(true);
 
             shell.Run(SampleCommand, "exit", 0).Task.Wait();
@@ -119,16 +119,16 @@ namespace Medallion.Shell.Tests
         [Test]
         public void TestThrowOnErrorWithTimeout()
         {
-            var command = TestShell.Run(SampleCommand, new object[] { "exit", 1 }, o => o.ThrowOnError().Timeout(TimeSpan.FromDays(1)));
+            var command = TestShell.Run(SampleCommand, ["exit", 1], o => o.ThrowOnError().Timeout(TimeSpan.FromDays(1)));
             var ex = Assert.Throws<AggregateException>(() => command.Task.Wait());
-            ex!.InnerExceptions.Select(e => e.GetType()).SequenceEqual(new[] { typeof(ErrorExitCodeException) })
+            ex!.InnerExceptions.Select(e => e.GetType()).SequenceEqual([typeof(ErrorExitCodeException)])
                 .ShouldEqual(true);
         }
 
         [Test]
         public void TestTimeout()
         {
-            var willTimeout = TestShell.Run(SampleCommand, new object[] { "sleep", 1000000 }, o => o.Timeout(TimeSpan.FromMilliseconds(200)));
+            var willTimeout = TestShell.Run(SampleCommand, ["sleep", 1000000], o => o.Timeout(TimeSpan.FromMilliseconds(200)));
             var ex = Assert.Throws<AggregateException>(() => willTimeout.Task.Wait());
             Assert.IsInstanceOf<TimeoutException>(ex!.InnerException);
         }
@@ -136,7 +136,7 @@ namespace Medallion.Shell.Tests
         [Test]
         public void TestZeroTimeout()
         {
-            var willTimeout = TestShell.Run(SampleCommand, new object[] { "sleep", 1000000 }, o => o.Timeout(TimeSpan.Zero));
+            var willTimeout = TestShell.Run(SampleCommand, ["sleep", 1000000], o => o.Timeout(TimeSpan.Zero));
             var ex = Assert.Throws<AggregateException>(() => willTimeout.Task.Wait());
             Assert.IsInstanceOf<TimeoutException>(ex!.InnerException);
         }
@@ -145,7 +145,7 @@ namespace Medallion.Shell.Tests
         public void TestCancellationAlreadyCanceled()
         {
             using var alreadyCanceled = new CancellationTokenSource(millisecondsDelay: 0);
-            var command = TestShell.Run(SampleCommand, new object[] { "sleep", 1000000 }, o => o.CancellationToken(alreadyCanceled.Token));
+            var command = TestShell.Run(SampleCommand, ["sleep", 1000000], o => o.CancellationToken(alreadyCanceled.Token));
             Assert.Throws<TaskCanceledException>(() => command.Wait());
             Assert.Throws<TaskCanceledException>(() => command.Result.ToString());
             command.Task.Status.ShouldEqual(TaskStatus.Canceled);
@@ -156,7 +156,7 @@ namespace Medallion.Shell.Tests
         public void TestCancellationNotCanceled()
         {
             using var notCanceled = new CancellationTokenSource();
-            var command = TestShell.Run(SampleCommand, new object[] { "sleep", 1000000 }, o => o.CancellationToken(notCanceled.Token));
+            var command = TestShell.Run(SampleCommand, ["sleep", 1000000], o => o.CancellationToken(notCanceled.Token));
             command.Task.Wait(50).ShouldEqual(false);
             command.Kill();
             command.Task.Wait(1000).ShouldEqual(true);
@@ -168,7 +168,7 @@ namespace Medallion.Shell.Tests
         {
             using var cancellationTokenSource = new CancellationTokenSource();
             var results = new SyncCollection();
-            var command = TestShell.Run(SampleCommand, new object[] { "echo", "--per-char" }, o => o.CancellationToken(cancellationTokenSource.Token)) > results;
+            var command = TestShell.Run(SampleCommand, ["echo", "--per-char"], o => o.CancellationToken(cancellationTokenSource.Token)) > results;
             command.StandardInput.WriteLine("hello");
             var timeout = Task.Delay(TimeSpan.FromSeconds(10));
             while (results.Count == 0 && !timeout.IsCompleted) { }
@@ -202,7 +202,7 @@ namespace Medallion.Shell.Tests
         {
             using var cancellationTokenSource = new CancellationTokenSource();
             var results = new List<string>();
-            var command = TestShell.Run(SampleCommand, new object[] { "echo" }, o => o.CancellationToken(cancellationTokenSource.Token)) > results;
+            var command = TestShell.Run(SampleCommand, ["echo"], o => o.CancellationToken(cancellationTokenSource.Token)) > results;
             command.StandardInput.WriteLine("hello");
             command.StandardInput.Close();
             command.Task.Wait(1000).ShouldEqual(true);
@@ -216,7 +216,7 @@ namespace Medallion.Shell.Tests
             var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(5));
             var command = TestShell.Run(
                 SampleCommand,
-                new object[] { "sleep", 1000000 },
+                ["sleep", 1000000],
                 o => o.CancellationToken(cancellationTokenSource.Token)
                     .Timeout(TimeSpan.FromMilliseconds(50))
             );
@@ -229,7 +229,7 @@ namespace Medallion.Shell.Tests
             var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
             var command = TestShell.Run(
                 SampleCommand,
-                new object[] { "sleep", 1000000 },
+                ["sleep", 1000000],
                 o => o.CancellationToken(cancellationTokenSource.Token)
                     .Timeout(TimeSpan.FromSeconds(5))
             );
@@ -484,10 +484,10 @@ namespace Medallion.Shell.Tests
                         command1.Process.StartInfo.Arguments.ShouldContain("--id1");
                         command2.Process.StartInfo.Arguments.ShouldContain("--id2");
 #endif
-                        command1.Processes.SequenceEqual(new[] { command1.Process });
-                        command2.Processes.SequenceEqual(new[] { command2.Process }).ShouldEqual(true);
+                        command1.Processes.SequenceEqual([command1.Process]);
+                        command2.Processes.SequenceEqual([command2.Process]).ShouldEqual(true);
                         pipeCommand.Process.ShouldEqual(command2.Process);
-                        pipeCommand.Processes.SequenceEqual(new[] { command1.Process, command2.Process }).ShouldEqual(true);
+                        pipeCommand.Processes.SequenceEqual([command1.Process, command2.Process]).ShouldEqual(true);
                     }
 
 #if NETFRAMEWORK
@@ -504,10 +504,10 @@ namespace Medallion.Shell.Tests
                     }
 #endif
 
-                    command1.ProcessIds.SequenceEqual(new[] { command1.ProcessId }).ShouldEqual(true);
-                    command2.ProcessIds.SequenceEqual(new[] { command2.ProcessId }).ShouldEqual(true);
+                    command1.ProcessIds.SequenceEqual([command1.ProcessId]).ShouldEqual(true);
+                    command2.ProcessIds.SequenceEqual([command2.ProcessId]).ShouldEqual(true);
                     pipeCommand.ProcessId.ShouldEqual(command2.ProcessId);
-                    pipeCommand.ProcessIds.SequenceEqual(new[] { command1.ProcessId, command2.ProcessId }).ShouldEqual(true);
+                    pipeCommand.ProcessIds.SequenceEqual([command1.ProcessId, command2.ProcessId]).ShouldEqual(true);
                 }
                 finally
                 {
@@ -609,7 +609,7 @@ namespace Medallion.Shell.Tests
         {
             using var command = TestShell.Run(
                 SampleCommand,
-                new object[] { "exit", 0 },
+                ["exit", 0],
                 options: o => o.Syntax((CommandLineSyntax)Activator.CreateInstance(PlatformCompatibilityHelper.DefaultCommandLineSyntax.GetType())!)
                     .DisposeOnExit(false)
             );

--- a/MedallionShell.Tests/Streams/MergedLinesEnumerableTest.cs
+++ b/MedallionShell.Tests/Streams/MergedLinesEnumerableTest.cs
@@ -21,14 +21,14 @@ namespace Medallion.Shell.Tests.Streams
 
             var enumerable1 = new MergedLinesEnumerable(empty1, nonEmpty1);
             var list1 = enumerable1.ToList();
-            list1.SequenceEqual(new[] { "abc", "def", "ghi", "jkl" })
+            list1.SequenceEqual(["abc", "def", "ghi", "jkl"])
                 .ShouldEqual(true, string.Join(", ", list1));
 
             var empty2 = new StringReader(string.Empty);
             var nonEmpty2 = new StringReader("a\nbb\nccc\n");
             var enumerable2 = new MergedLinesEnumerable(nonEmpty2, empty2);
             var list2 = enumerable2.ToList();
-            list2.SequenceEqual(new[] { "a", "bb", "ccc" })
+            list2.SequenceEqual(["a", "bb", "ccc"])
                 .ShouldEqual(true, string.Join(", ", list2));
         }
 
@@ -53,8 +53,8 @@ namespace Medallion.Shell.Tests.Streams
         [Test]
         public void TestBothArePopulatedDifferenceSizes()
         {
-            var lines1 = string.Join("\n", new[] { "x", "y", "z" });
-            var lines2 = string.Join("\n", new[] { "1", "2", "3", "4", "5" });
+            var lines1 = string.Join("\n", ["x", "y", "z"]);
+            var lines2 = string.Join("\n", ["1", "2", "3", "4", "5"]);
 
             var list1 = new MergedLinesEnumerable(new StringReader(lines1), new StringReader(lines2))
                 .ToList();

--- a/MedallionShell.Tests/Streams/ProcessIOCancellationTest.cs
+++ b/MedallionShell.Tests/Streams/ProcessIOCancellationTest.cs
@@ -28,7 +28,7 @@ internal class ProcessIOCancellationTest
                 Arguments = "echo",
 #else
                 FileName = PlatformCompatibilityTests.DotNetPath,
-                Arguments = PlatformCompatibilityHelper.DefaultCommandLineSyntax.CreateArgumentString(new[] { PlatformCompatibilityTests.SampleCommandPath, "echo" }),
+                Arguments = PlatformCompatibilityHelper.DefaultCommandLineSyntax.CreateArgumentString([PlatformCompatibilityTests.SampleCommandPath, "echo"]),
 #endif
                 RedirectStandardInput = true,
                 RedirectStandardOutput = true,
@@ -45,7 +45,7 @@ internal class ProcessIOCancellationTest
                 // For write, loop to fill up the buffer; eventually we'll block
                 while (true) { await DoIOWithCancellationAsync(process.StandardInput.BaseStream, cancellationTokenSource.Token); }
             });
-            Task.WaitAny(new[] { readTask, writeTask }, TimeSpan.FromSeconds(0.5)).ShouldEqual(-1);
+            Task.WaitAny([readTask, writeTask], TimeSpan.FromSeconds(0.5)).ShouldEqual(-1);
             
             cancellationTokenSource.Cancel();
 

--- a/MedallionShell/AttachedCommand.cs
+++ b/MedallionShell/AttachedCommand.cs
@@ -42,7 +42,7 @@ namespace Medallion.Shell
                 TaskContinuationOptions.ExecuteSynchronously
             );
 
-            this.processes = new Lazy<ReadOnlyCollection<Process>>(() => new ReadOnlyCollection<Process>(new[] { this.process }));
+            this.processes = new Lazy<ReadOnlyCollection<Process>>(() => new ReadOnlyCollection<Process>([this.process]));
         }
 
         public override Process Process
@@ -77,7 +77,7 @@ namespace Medallion.Shell
             }
         }
 
-        public override IReadOnlyList<int> ProcessIds => new ReadOnlyCollection<int>(new[] { this.ProcessId });
+        public override IReadOnlyList<int> ProcessIds => new ReadOnlyCollection<int>([this.ProcessId]);
 
         public override ProcessStreamWriter StandardInput => throw new InvalidOperationException(StreamPropertyExceptionMessage);
 

--- a/MedallionShell/ProcessCommand.cs
+++ b/MedallionShell/ProcessCommand.cs
@@ -118,7 +118,7 @@ namespace Medallion.Shell
         }
 
         private IReadOnlyList<Process>? processes;
-        public override IReadOnlyList<Process> Processes => this.processes ??= new ReadOnlyCollection<Process>(new[] { this.Process });
+        public override IReadOnlyList<Process> Processes => this.processes ??= new ReadOnlyCollection<Process>([this.Process]);
 
         private readonly object processIdOrExceptionDispatchInfo;
         public override int ProcessId
@@ -137,7 +137,7 @@ namespace Medallion.Shell
         }
 
         private IReadOnlyList<int>? processIds;
-        public override IReadOnlyList<int> ProcessIds => this.processIds ??= new ReadOnlyCollection<int>(new[] { this.ProcessId });
+        public override IReadOnlyList<int> ProcessIds => this.processIds ??= new ReadOnlyCollection<int>([this.ProcessId]);
 
         private readonly ProcessStreamWriter? standardInput;
         public override ProcessStreamWriter StandardInput => this.standardInput ?? throw new InvalidOperationException("Standard input is not redirected");

--- a/MedallionShell/Shims/Shims.cs
+++ b/MedallionShell/Shims/Shims.cs
@@ -14,10 +14,10 @@ internal static class Shims
 
     private static class Empty<T>
     {
-        public static readonly T[] Array = new T[0];
+        public static readonly T[] Array = [];
     }
 #else
-        Array.Empty<T>();
+        [];
 #endif
 
     public static Task<T> CanceledTask<T>(CancellationToken cancellationToken)

--- a/MedallionShell/Shims/SpanShims.cs
+++ b/MedallionShell/Shims/SpanShims.cs
@@ -34,13 +34,11 @@ internal readonly struct Memory<T>
         System.Array.Copy(sourceArray: this.Array, sourceIndex: this.Offset, destinationArray: destination.Array, destinationIndex: destination.Offset, length: this.Length);
 }
 
-internal readonly ref struct Span<T>
+internal readonly ref struct Span<T>(Memory<T> memory)
 {
-    public readonly Memory<T> Memory;
+    public readonly Memory<T> Memory = memory;
 
     public int Length => this.Memory.Length;
-
-    public Span(Memory<T> memory) { this.Memory = memory; }
 
     public static implicit operator Span<T>(T[] array) => new(new(array, 0, array.Length));
 

--- a/MedallionShell/Shims/ValueTupleShims.cs
+++ b/MedallionShell/Shims/ValueTupleShims.cs
@@ -3,17 +3,10 @@
 
 namespace System;
 
-internal struct ValueTuple<T1, T2, T3>
+internal struct ValueTuple<T1, T2, T3>(T1 item1, T2 item2, T3 item3)
 {
-    public T1 Item1;
-    public T2 Item2;
-    public T3 Item3;
-
-    public ValueTuple(T1 item1, T2 item2, T3 item3)
-    {
-        this.Item1 = item1;
-        this.Item2 = item2;
-        this.Item3 = item3;
-    }
+    public T1 Item1 = item1;
+    public T2 Item2 = item2;
+    public T3 Item3 = item3;
 }
 #endif

--- a/MedallionShell/Signals/WindowsProcessSignaler.cs
+++ b/MedallionShell/Signals/WindowsProcessSignaler.cs
@@ -34,7 +34,7 @@ namespace Medallion.Shell.Signals
             var exeFile = await DeploySignalerExeAsync().ConfigureAwait(false);
             try
             {
-                var command = Command.Run(exeFile, new object[] { processId, (int)signal });
+                var command = Command.Run(exeFile, [processId, (int)signal]);
                 return (await command.Task.ConfigureAwait(false)).Success;
             }
             finally

--- a/MedallionShell/Streams/LongRunningTaskScheduler.cs
+++ b/MedallionShell/Streams/LongRunningTaskScheduler.cs
@@ -80,7 +80,7 @@ internal sealed class LongRunningTaskScheduler : TaskScheduler
         WorkerThreadState.StartNew(this, task);
     }
 
-    protected override IEnumerable<Task> GetScheduledTasks() => Enumerable.Empty<Task>(); // all tasks run immediately
+    protected override IEnumerable<Task> GetScheduledTasks() => []; // all tasks run immediately
 
     protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued) => false;
     

--- a/MedallionShell/Streams/Pipe.cs
+++ b/MedallionShell/Streams/Pipe.cs
@@ -666,56 +666,6 @@ namespace Medallion.Shell.Streams
 
         #region ---- Output Stream ----
         private sealed class PipeOutputStream(Pipe pipe) : Stream
-
-/* Unmerged change from project 'MedallionShell (net46)'
-Before:
-        {
-            private readonly Pipe pipe;
-
-            public PipeOutputStream(Pipe pipe) { this.pipe = pipe; }
-After:
-        {
-*/
-
-/* Unmerged change from project 'MedallionShell (netstandard1.3)'
-Before:
-        {
-            private readonly Pipe pipe;
-
-            public PipeOutputStream(Pipe pipe) { this.pipe = pipe; }
-After:
-        {
-*/
-
-/* Unmerged change from project 'MedallionShell (net45)'
-Before:
-        {
-            private readonly Pipe pipe;
-
-            public PipeOutputStream(Pipe pipe) { this.pipe = pipe; }
-After:
-        {
-*/
-
-/* Unmerged change from project 'MedallionShell (net471)'
-Before:
-        {
-            private readonly Pipe pipe;
-
-            public PipeOutputStream(Pipe pipe) { this.pipe = pipe; }
-After:
-        {
-*/
-
-/* Unmerged change from project 'MedallionShell (netstandard2.0)'
-Before:
-        {
-            private readonly Pipe pipe;
-
-            public PipeOutputStream(Pipe pipe) { this.pipe = pipe; }
-After:
-        {
-*/
         {
 #if !NETSTANDARD1_3
             public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state)

--- a/MedallionShell/Streams/Pipe.cs
+++ b/MedallionShell/Streams/Pipe.cs
@@ -494,12 +494,8 @@ namespace Medallion.Shell.Streams
         #endregion
 
         #region ---- Input Stream ----
-        private sealed class PipeInputStream : Stream
+        private sealed class PipeInputStream(Pipe pipe) : Stream
         {
-            private readonly Pipe pipe;
-
-            public PipeInputStream(Pipe pipe) { this.pipe = pipe; }
-
 #if !NETSTANDARD1_3
             public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state)
             {
@@ -519,22 +515,13 @@ namespace Medallion.Shell.Streams
             }
 #endif
 
-            private sealed class AsyncWriteResult : IAsyncResult
+            private sealed class AsyncWriteResult(object? state, Task writeTask, Pipe.PipeInputStream stream) : IAsyncResult
             {
-                private readonly object? state;
-                
-                public AsyncWriteResult(object? state, Task writeTask, PipeInputStream stream)
-                {
-                    this.state = state;
-                    this.WriteTask = writeTask;
-                    this.Stream = stream;
-                }
+                public Task WriteTask { get; } = writeTask;
 
-                public Task WriteTask { get; }
+                public Stream Stream { get; } = stream;
 
-                public Stream Stream { get; }
-
-                object? IAsyncResult.AsyncState => this.state;
+                object? IAsyncResult.AsyncState => state;
 
                 WaitHandle IAsyncResult.AsyncWaitHandle => this.WriteTask.As<IAsyncResult>().AsyncWaitHandle;
 
@@ -564,7 +551,7 @@ namespace Medallion.Shell.Streams
             {
                 if (disposing)
                 {
-                    this.pipe.CloseWriteSide();
+                    pipe.CloseWriteSide();
                 }
             }
 
@@ -639,7 +626,7 @@ namespace Medallion.Shell.Streams
                 this.WriteAsync(buffer, offset, count).GetAwaiter().GetResult();
 
             public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
-                this.pipe.WriteAsync(buffer, offset, count, TimeSpan.FromMilliseconds(this.WriteTimeout), cancellationToken);
+                pipe.WriteAsync(buffer, offset, count, TimeSpan.FromMilliseconds(this.WriteTimeout), cancellationToken);
 
             public override void WriteByte(byte value) => base.WriteByte(value);
 
@@ -678,12 +665,58 @@ namespace Medallion.Shell.Streams
         #endregion
 
         #region ---- Output Stream ----
-        private sealed class PipeOutputStream : Stream
+        private sealed class PipeOutputStream(Pipe pipe) : Stream
+
+/* Unmerged change from project 'MedallionShell (net46)'
+Before:
         {
             private readonly Pipe pipe;
 
             public PipeOutputStream(Pipe pipe) { this.pipe = pipe; }
+After:
+        {
+*/
 
+/* Unmerged change from project 'MedallionShell (netstandard1.3)'
+Before:
+        {
+            private readonly Pipe pipe;
+
+            public PipeOutputStream(Pipe pipe) { this.pipe = pipe; }
+After:
+        {
+*/
+
+/* Unmerged change from project 'MedallionShell (net45)'
+Before:
+        {
+            private readonly Pipe pipe;
+
+            public PipeOutputStream(Pipe pipe) { this.pipe = pipe; }
+After:
+        {
+*/
+
+/* Unmerged change from project 'MedallionShell (net471)'
+Before:
+        {
+            private readonly Pipe pipe;
+
+            public PipeOutputStream(Pipe pipe) { this.pipe = pipe; }
+After:
+        {
+*/
+
+/* Unmerged change from project 'MedallionShell (netstandard2.0)'
+Before:
+        {
+            private readonly Pipe pipe;
+
+            public PipeOutputStream(Pipe pipe) { this.pipe = pipe; }
+After:
+        {
+*/
+        {
 #if !NETSTANDARD1_3
             public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state)
             {
@@ -698,22 +731,13 @@ namespace Medallion.Shell.Streams
             }
 #endif
 
-            private sealed class AsyncReadResult : IAsyncResult
+            private sealed class AsyncReadResult(object? state, Task<int> readTask, Pipe.PipeOutputStream stream) : IAsyncResult
             {
-                private readonly object? state;
-                
-                public AsyncReadResult(object? state, Task<int> readTask, PipeOutputStream stream)
-                {
-                    this.state = state;
-                    this.ReadTask = readTask;
-                    this.Stream = stream;
-                }
+                public Task<int> ReadTask { get; } = readTask;
 
-                public Task<int> ReadTask { get; }
+                public Stream Stream { get; } = stream;
 
-                public Stream Stream { get; }
-
-                object? IAsyncResult.AsyncState => this.state;
+                object? IAsyncResult.AsyncState => state;
 
                 WaitHandle IAsyncResult.AsyncWaitHandle => this.ReadTask.As<IAsyncResult>().AsyncWaitHandle;
 
@@ -751,7 +775,7 @@ namespace Medallion.Shell.Streams
             {
                 if (disposing)
                 {
-                    this.pipe.CloseReadSide();
+                    pipe.CloseReadSide();
                 }
             }
 
@@ -792,14 +816,14 @@ namespace Medallion.Shell.Streams
             {
                 Throw.IfInvalidBuffer(buffer, offset, count);
 
-                return this.pipe.Read(buffer.AsSpan(offset, count), TimeSpan.FromMilliseconds(this.readTimeout));
+                return pipe.Read(buffer.AsSpan(offset, count), TimeSpan.FromMilliseconds(this.readTimeout));
             }
 
             public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
             {
                 Throw.IfInvalidBuffer(buffer, offset, count);
 
-                return this.pipe.ReadAsync(new(buffer, offset, count), TimeSpan.FromMilliseconds(this.readTimeout), cancellationToken);
+                return pipe.ReadAsync(new(buffer, offset, count), TimeSpan.FromMilliseconds(this.readTimeout), cancellationToken);
             }
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1
@@ -809,7 +833,7 @@ namespace Medallion.Shell.Streams
                 throw ReadOnly();
 
             public override int Read(Span<byte> buffer) =>
-                this.pipe.Read(buffer, TimeSpan.FromMilliseconds(this.readTimeout));
+                pipe.Read(buffer, TimeSpan.FromMilliseconds(this.readTimeout));
 
             public override int ReadByte()
             {
@@ -819,7 +843,7 @@ namespace Medallion.Shell.Streams
             }
 
             public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken) =>
-                new(this.pipe.ReadAsync(buffer, TimeSpan.FromMilliseconds(this.readTimeout), cancellationToken)); 
+                new(pipe.ReadAsync(buffer, TimeSpan.FromMilliseconds(this.readTimeout), cancellationToken)); 
 #else
             public override int ReadByte() => base.ReadByte();
 #endif

--- a/MedallionShell/Streams/ProcessStreamReader.cs
+++ b/MedallionShell/Streams/ProcessStreamReader.cs
@@ -31,15 +31,9 @@ namespace Medallion.Shell.Streams
         /// </summary>
         public IEnumerable<string> GetLines() => new LinesEnumerable(this);
 
-        private class LinesEnumerable : IEnumerable<string>
+        private class LinesEnumerable(TextReader reader) : IEnumerable<string>
         {
-            private readonly TextReader reader;
             private int consumed;
-
-            public LinesEnumerable(TextReader reader)
-            {
-                this.reader = reader;
-            }
 
             IEnumerator<string> IEnumerable<string>.GetEnumerator()
             {
@@ -54,7 +48,7 @@ namespace Medallion.Shell.Streams
             private IEnumerator<string> GetEnumeratorInternal()
             {
                 string? line;
-                while ((line = this.reader.ReadLine()) != null)
+                while ((line = reader.ReadLine()) != null)
                 {
                     yield return line;
                 }

--- a/SampleCommand/Program.cs
+++ b/SampleCommand/Program.cs
@@ -144,7 +144,7 @@ namespace SampleCommand
                     {
                         throw new ArgumentException($"Unknown test method '{args[1]}'");
                     }
-                    method.Invoke(null, new object[0]);
+                    method.Invoke(null, []);
                     break;
                 default:
                     Console.Error.WriteLine("Unrecognized mode " + args[0]);

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ image:
   - Ubuntu2204
 
 init:
-  - sh: |
+  - sh: >
       sudo apt-get update &&
       sudo apt-get install -y dotnet-sdk-8.0
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,12 @@ version: 1.0.{build}
 
 image: 
   - Visual Studio 2022
-  - Ubuntu
+  - Ubuntu2204
+
+init:
+  - sh: |
+      sudo apt-get update &&
+      sudo apt-get install -y dotnet-sdk-8.0
 
 build_script:
   # on linux, it seems like msbuild goes parallel such that if we don't build ProcessSignaler first, we won't have the net45 binary

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,11 +4,6 @@ image:
   - Visual Studio 2022
   - Ubuntu2204
 
-init:
-  - sh: >
-      sudo apt-get update &&
-      sudo apt-get install -y dotnet-sdk-8.0
-
 build_script:
   # on linux, it seems like msbuild goes parallel such that if we don't build ProcessSignaler first, we won't have the net45 binary
   # to pack into the non-net45 builds

--- a/stylecop.analyzers.ruleset
+++ b/stylecop.analyzers.ruleset
@@ -12,7 +12,7 @@
     <Rule Id="SA1111" Action="None" />
     <Rule Id="SA1114" Action="None" />
     <Rule Id="SA1124" Action="None" />
-  	<Rule Id="SA1127" Action="None" />
+    <Rule Id="SA1127" Action="None" />
     <Rule Id="SA1132" Action="None" />
     <Rule Id="SA1200" Action="None" />
     <Rule Id="SA1201" Action="None" />

--- a/stylecop.analyzers.ruleset
+++ b/stylecop.analyzers.ruleset
@@ -1,16 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <RuleSet Name="Rules for StyleCop.Analyzers" Description="Code analysis rules" ToolsVersion="15.0">
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
-	<Rule Id="SA1000" Action="None" />
-	<!-- just too annoying for iteration -->
+    <Rule Id="SA1000" Action="None" />
+    <!-- just too annoying for iteration -->
     <Rule Id="SA1005" Action="None" />
-	<Rule Id="SA1009" Action="None" />
+    <Rule Id="SA1009" Action="None" />
+    <!-- This no longer makes sense with the introduction of collection expressions in C# 12. -->
+    <Rule Id="SA1010" Action="None" />
     <Rule Id="SA1028" Action="None" />
     <Rule Id="SA1108" Action="None" />
     <Rule Id="SA1111" Action="None" />
     <Rule Id="SA1114" Action="None" />
     <Rule Id="SA1124" Action="None" />
-	<Rule Id="SA1127" Action="None" />
+  	<Rule Id="SA1127" Action="None" />
     <Rule Id="SA1132" Action="None" />
     <Rule Id="SA1200" Action="None" />
     <Rule Id="SA1201" Action="None" />


### PR DESCRIPTION
### Motivation
The current `Ubuntu` pipeline doesn't have .NET 8 SDK installed.

### Background
According to https://www.appveyor.com/docs/linux-images-software/, we're currently using Ubuntu 18.04 (image name: `Ubuntu`) in the CI pipeline.

However, .NET 8 SDK is not installed in any of default Ubuntu images according to the same page. Until https://github.com/appveyor/ci/issues/3908 is complete, we'll need to install .NET SDK manually.

However, you cannot install .NET 8 on Ubuntu 18.04 per https://learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu-1804.

### Changes in the PR
Updated the image to the latest Ubuntu version (that's supported in AppVeyor) 22.04 and manually installing .NET 8 SDK per https://learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu-2204.

### Testing
- I included C# 12 changes like primary constructors and collection expressions, which come with .NET 8 SDK, so this should be a good litmus test.
- The Windows build is failing due to #110. 